### PR TITLE
Updating package install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Personal R package
 
 # Installation
-devtools::install_github('netterie/Rjkb')
+devtools::install_github("netterie/Rjkb/Rjkb")


### PR DESCRIPTION
The "Rjkb" package is within the sub-directory called "Rjkb".

The original `devtools::install_github("netterie/Rjkb")` code was giving me errors.

Changing it to `devtools::install_github("netterie/Rjkb/Rjkb")` fixes this! ☺️